### PR TITLE
Fixed bug which caused guest accounts to keep getting reset

### DIFF
--- a/lib/providers/authentication_service.dart
+++ b/lib/providers/authentication_service.dart
@@ -67,9 +67,11 @@ class AuthenticationService {
       UserCredential result = await _auth.signInAnonymously();
       User? user = result.user;
       await user?.updateDisplayName("Guest");
-      await addNewUser(userId: user!.uid).then(
-        (_) => debugPrint('✔️ Initialised user in Firestore'),
-      );
+      if (result.additionalUserInfo?.isNewUser ?? false) {
+        await addNewUser(userId: user!.uid).then(
+          (_) => debugPrint('✔️ Initialised user in Firestore'),
+        );
+      }
       debugPrint("✔️ Signed in anonymously");
     } on FirebaseAuthException catch (e) {
       debugPrint("❌ Anonymous Login failed with code: ${e.code}");


### PR DESCRIPTION
### Why was this happening
When a user signs in using a guest account, it always ran the function which initialises a new user into firestore.

However, guest accounts seem to be generated based on the user's device, hence when a user with an existing guest account logs in again it wiped their accounts to the base state.

### Fix
The bus was fixed by adding a check to see if the user's account was a new one when signing in as a guest