### PR TITLE
⚡ Added messages when no bus timings are available

### DIFF
--- a/lib/screens/bus_timing_screen.dart
+++ b/lib/screens/bus_timing_screen.dart
@@ -193,7 +193,6 @@ class _BusTimingScreenState extends State<BusTimingScreen> {
   @override
   Widget build(BuildContext context) {
     User? user = context.watch<User?>();
-
     return Scaffold(
       appBar: AppBar(
         title: GestureDetector(
@@ -232,10 +231,10 @@ class _BusTimingScreenState extends State<BusTimingScreen> {
                                 padding: const EdgeInsets.all(16.0),
                                 child: Text(
                                   Jiffy().hour > 5
-                                      ? 'No Bus Services are operating currently'
+                                      ? '🦥 All the buses are lepaking 🦥'
                                       : "💤 Buses are sleeping 💤",
                                   style: const TextStyle(
-                                    fontSize: 24,
+                                    fontSize: 21,
                                     fontWeight: FontWeight.w500,
                                   ),
                                   textAlign: TextAlign.center,

--- a/lib/screens/bus_timing_screen.dart
+++ b/lib/screens/bus_timing_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:http/http.dart' as http;
+import 'package:jiffy/jiffy.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:transito/models/arrival_info.dart';
@@ -225,17 +226,35 @@ class _BusTimingScreenState extends State<BusTimingScreen> {
                     // notification listener to hide the fab when the user is scrolling down the list
                     return NotificationListener<UserScrollNotification>(
                       onNotification: (notification) => hideFabOnScroll(notification),
-                      child: ListView.separated(
-                          itemBuilder: (context, int index) {
-                            return BusTimingRow(
-                              serviceInfo: snapshot.data!.services[index],
-                              userLatLng: widget.busStopLocation,
-                              isETAminutes: userSettings.isETAminutes,
-                            );
-                          },
-                          padding: const EdgeInsets.only(top: 12, bottom: 32, left: 12, right: 12),
-                          separatorBuilder: (BuildContext context, int index) => const Divider(),
-                          itemCount: snapshot.data!.services.length),
+                      child: snapshot.data!.services.isEmpty
+                          ? Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16.0),
+                                child: Text(
+                                  Jiffy().hour > 5
+                                      ? 'No Bus Services are operating currently'
+                                      : "💤 Buses are sleeping 💤",
+                                  style: const TextStyle(
+                                    fontSize: 24,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            )
+                          : ListView.separated(
+                              itemBuilder: (context, int index) {
+                                return BusTimingRow(
+                                  serviceInfo: snapshot.data!.services[index],
+                                  userLatLng: widget.busStopLocation,
+                                  isETAminutes: userSettings.isETAminutes,
+                                );
+                              },
+                              padding:
+                                  const EdgeInsets.only(top: 12, bottom: 32, left: 12, right: 12),
+                              separatorBuilder: (BuildContext context, int index) =>
+                                  const Divider(),
+                              itemCount: snapshot.data!.services.length),
                     );
                   } else if (snapshot.hasError) {
                     // return Text("${snapshot.error}");

--- a/lib/widgets/favourites_timing_card.dart
+++ b/lib/widgets/favourites_timing_card.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:jiffy/jiffy.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:transito/widgets/bus_timing_row.dart';
@@ -147,25 +148,41 @@ class _FavouritesTimingCardState extends State<FavouritesTimingCard> {
                                       color: AppColors.kindaGrey),
                                 ),
                               ),
-                              ListView.separated(
-                                  itemBuilder: (context, int index) {
-                                    return Transform.scale(
-                                      scale: 0.9,
-                                      child: BusTimingRow(
-                                        serviceInfo: snapshot.data![index],
-                                        userLatLng: widget.busStopLocation,
-                                        isETAminutes: userSettings.isETAminutes,
+                              snapshot.data!.isEmpty
+                                  ? Center(
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(16.0),
+                                        child: Text(
+                                          Jiffy().hour > 5
+                                              ? '🦥 Your favourites are lepaking 🦥'
+                                              : "💤 Buses are sleeping 💤",
+                                          style: const TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                          textAlign: TextAlign.center,
+                                        ),
                                       ),
-                                    );
-                                  },
-                                  separatorBuilder: (BuildContext context, int index) =>
-                                      const SizedBox(
-                                        height: 6,
-                                      ),
-                                  physics: const NeverScrollableScrollPhysics(),
-                                  padding: const EdgeInsets.only(bottom: 18),
-                                  shrinkWrap: true,
-                                  itemCount: snapshot.data!.length),
+                                    )
+                                  : ListView.separated(
+                                      itemBuilder: (context, int index) {
+                                        return Transform.scale(
+                                          scale: 0.9,
+                                          child: BusTimingRow(
+                                            serviceInfo: snapshot.data![index],
+                                            userLatLng: widget.busStopLocation,
+                                            isETAminutes: userSettings.isETAminutes,
+                                          ),
+                                        );
+                                      },
+                                      separatorBuilder: (BuildContext context, int index) =>
+                                          const SizedBox(
+                                            height: 6,
+                                          ),
+                                      physics: const NeverScrollableScrollPhysics(),
+                                      padding: const EdgeInsets.only(bottom: 18),
+                                      shrinkWrap: true,
+                                      itemCount: snapshot.data!.length),
                             ],
                           ),
                         ),


### PR DESCRIPTION
# Description

When there are no bus services operating the bus timing screen and the favourites card did not display anything at all. This could result in the user thinking something had gone wrong with the application. 

These are the changes that were made to fix this issue
- Added 2 messages to notify users that there are no buses/favourites that are currently in operation at that bus stop
    - If the time is between 12am - 5am, the message would be 
      > 💤 Buses are sleeping 💤
    - For any other scenario, the message would either be 
      > 🦥 All the buses are lepaking 🦥
      > -----------------or-------------------
      > 🦥 Your favourites are lepaking 🦥
        
        depending on if it is displayed in the bus timing screen or favourites card respectively

## Type of change

Tick the relevant option

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

**Test Configuration**:
* Device/Emulator: Pixel 3a Emulator
* Android version: API 31


