### PR TITLE
🐞 Fixed accentColour showing an extra 'FF' inside settings

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -393,7 +393,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                       if (val?.alpha != 255) {
                                         return "Please select a fully opaque colour";
                                       }
-                                      if ('0x${val.toString().substring(8, 16).toUpperCase()}' ==
+                                      if ('0x${val.toString().substring(10, 16).toUpperCase()}' ==
                                           snapshot.data!.accentColour) {
                                         return "This is already your accent colour";
                                       }


### PR DESCRIPTION
# Description

Inside the settings page, the accent colour displayed to the user shows an extra FF so if the colour is `#7E6BFF`, it'll show `#FF7E6BFF` instead.

Fixes # N.A.

## Type of change

Tick the relavent option

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

*I am praying it works*

**Test Configuration**:
* Device/Emulator: N.A.
* Android version: N.A.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

